### PR TITLE
Verbose level

### DIFF
--- a/CPPLOGGER.h
+++ b/CPPLOGGER.h
@@ -225,7 +225,14 @@ namespace logger {
 	/**
 	 * Variadic argument function for printing information logs to screen.
 	 */
-	#define info(fmt, ...) _info_(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
+	#define info(...) _info_(__FILE__, __LINE__, __VA_ARGS__)
+	inline void _info_(const char* _file_, const int line, const int cvl, const int avl, const char* fmt, ...) {
+		if (_enable_ && cvl >= avl) {
+			va_start(__args__, fmt);
+			print(ANSI_GREEN, "INFO");
+		}
+	}
+
 	inline void _info_(const char* _file_, const int line, const char* fmt, ...) {
 		if (_enable_) {
 			va_start(__args__, fmt);
@@ -243,7 +250,14 @@ namespace logger {
 	/**
 	 * Variadic argument function for printing error logs to screen.
 	 */
-	#define error(fmt, ...) _error_(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
+	#define error(...) _error_(__FILE__, __LINE__, __VA_ARGS__)
+	inline void _error_(const char* _file_, const int line, const int cvl, const int avl, const char* fmt, ...) {
+		if (_enable_ && cvl >= avl) {
+			va_start(__args__, fmt);
+			print(ANSI_RED, " ERR");
+		}
+	}
+
 	inline void _error_(const char* _file_, const int line, const char* fmt, ...) {
 		if (_enable_) {
 			va_start(__args__, fmt);
@@ -261,11 +275,18 @@ namespace logger {
 	/**
 	 * Variadic argument function for printing warning logs to screen.
 	 */
-	#define warning(fmt, ...) _warning_(__FILE__, __LINE__, fmt, ##__VA_ARGS__)
+	#define warning(...) _warning_(__FILE__, __LINE__, __VA_ARGS__)
+	inline void _warning_(const char* _file_, const int line, const int cvl, const int avl, const char* fmt, ...) {
+		if (_enable_ && cvl >= avl) {
+			va_start(__args__, fmt);
+			print(ANSI_PURPLE, "WARN");
+		}
+	}
+
 	inline void _warning_(const char* _file_, const int line, const char* fmt, ...) {
 		if (_enable_) {
 			va_start(__args__, fmt);
-			print(ANSI_BLUE, "WARN");
+			print(ANSI_PURPLE, "WARN");
 		}
 	}
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,30 @@ int main() {
 }
 ```
 
+#### Verbose Level 
+```c++
+#include <CPPLOGGER.h>
+
+/**
+ * The following should always be called only in the main translation unit.
+ * This is to default initialize the logger flags.
+ */
+logger_init();
+
+int main() {
+	int verbose_level = 0;
+
+	logger::info(verbose_level, 1, "This should only be printed at verbose level 1.");
+
+	logger::info("Current verbose level: %d", verbose_level);
+	logger::info("Incrementing verbose level by one: %d", ++verbose_level);
+	logger::info("Current verbose level: %d", verbose_level);
+
+	logger::info(verbose_level, 1, "This should only be printed at verbose level 1.");
+}
+
+```
+
 #### Get type of a variable
 ```c++
 #include <CPPLOGGER.h>

--- a/examples/makefile
+++ b/examples/makefile
@@ -56,13 +56,4 @@ verbosity: verbosity.cpp ../CPPLOGGER.h
 	$(CC) $(CFLAGS) $(INCLUDE_DIR) $< -o ./bin/$@
 
 clean:
-	rm -rf ./bin/basic_usage
-	rm -rf ./bin/typographic_example
-	rm -rf ./bin/disable_logging
-	rm -rf ./bin/time_stamp
-	rm -rf ./bin/multi_thread
-	rm -rf ./bin/print_thread_id
-	rm -rf ./bin/log_type
-	rm -rf ./bin/file_name
-	rm -rf ./bin/line_number
-	rm -rf ./bin/no_file_line
+	rm -rf ./bin/

--- a/examples/makefile
+++ b/examples/makefile
@@ -13,7 +13,8 @@ all: \
 	log_type\
 	file_name\
 	line_number\
-	no_file_line
+	no_file_line\
+	verbosity
 	
 run_all: all
 	@python3 ./run_all.py
@@ -49,6 +50,9 @@ line_number: line_number.cpp ../CPPLOGGER.h
 	$(CC) $(CFLAGS) $(INCLUDE_DIR) $< -o ./bin/$@
 	
 no_file_line: no_file_line.cpp ../CPPLOGGER.h
+	$(CC) $(CFLAGS) $(INCLUDE_DIR) $< -o ./bin/$@
+
+verbosity: verbosity.cpp ../CPPLOGGER.h
 	$(CC) $(CFLAGS) $(INCLUDE_DIR) $< -o ./bin/$@
 
 clean:

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -2,9 +2,11 @@ import os
 import stat
 import subprocess
 
+directory = './bin'
+
 executable = stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
 executables = []
-for filename in os.listdir('.'):
+for filename in os.listdir(directory):
     if os.path.isfile(filename):
         st = os.stat(filename)
         mode = st.st_mode
@@ -15,7 +17,7 @@ for exec in executables:
 	print("".join(["="]*97))
 	print("Running", exec)
 	print("".join(["="]*97))
-	arch = subprocess.check_output("./"+exec, shell=True);
+	arch = subprocess.check_output(directory+exec, shell=True);
 	for i in arch.decode().split("\n"):
 		print(" ", i)
 	print()

--- a/examples/verbosity.cpp
+++ b/examples/verbosity.cpp
@@ -6,6 +6,11 @@
  */
 
 #include <CPPLOGGER.h>
+
+/**
+ * The following should always be called only in the main translation unit.
+ * This is to default initialize the logger flags.
+ */
 logger_init();
 
 int main() {

--- a/examples/verbosity.cpp
+++ b/examples/verbosity.cpp
@@ -1,0 +1,21 @@
+/*
+ * verbosity.cpp
+ *
+ *  Created on: Jun 1, 2020
+ *      Author: sajeeb
+ */
+
+#include <CPPLOGGER.h>
+logger_init();
+
+int main() {
+	int verbose_level = 0;
+
+	logger::info(verbose_level, 1, "This should only be printed at verbose level 1.");
+
+	logger::info("Current verbose level: %d", verbose_level);
+	logger::info("Incrementing verbose level by one: %d", ++verbose_level);
+	logger::info("Current verbose level: %d", verbose_level);
+
+	logger::info(verbose_level, 1, "This should only be printed at verbose level 1.");
+}


### PR DESCRIPTION
Added verbose level option to all three log levels. This option allows users to set the amount of logging that is done. For more information refer to the verbosity example in the readme file.